### PR TITLE
request retrying & file content reading

### DIFF
--- a/lib/paged-request.js
+++ b/lib/paged-request.js
@@ -1,7 +1,7 @@
 "use strict";
 var _ = require("lodash"),
     url = require("url"),
-    request = require("request"),
+    request = require("requestretry"),
     EventEmitter = require("events").EventEmitter,
     util = require("util"),
     API_BASE = "/rest/api/1.0/";
@@ -45,9 +45,11 @@ util.inherits(PagedRequest, EventEmitter);
             user: this.connectionDetails.user,
             pass: this.connectionDetails.password
         };
+        options.maxAttempts = 5;
+        options.retryDelay = 500;
+
         //console.log(options.uri);
         request(options, _.bind(function(error, response, body) {
-            //console.log(body);
             if(error) {
                 errback(error);
                 return;
@@ -59,7 +61,15 @@ util.inherits(PagedRequest, EventEmitter);
             this.atLastPage  = body.isLastPage;
             this.setIndex(this.limit+this.cursor|| 0);
 
-            callback(body.values);
+            //body has different structures for different request types
+            if (typeof(body.values) != "undefined") {
+              callback(body.values);
+            } else if (typeof(body.lines) != "undefined") {
+              callback(body.lines);
+            } else {
+              callback(body);
+              return;
+            }
         }, this));
     },
 

--- a/lib/stash.js
+++ b/lib/stash.js
@@ -1,7 +1,7 @@
 "use strict";
 var _ = require("lodash"),
     url = require("url"),
-    request = require("request"),
+    request = require("requestretry"),
     PagedRequest = require("./paged-request").PagedRequest,
     API_BASE = "/rest/api/1.0/";
 
@@ -52,6 +52,8 @@ var StashApi = exports.StashApi = function(protocol, hostname, port, user, passw
             user: this.user,
             pass: this.password
         };
+        options.maxAttempts = 5;
+        options.retryDelay = 500;
 
         request(options, function(error, response, body) {
             if(error) {
@@ -99,9 +101,14 @@ var StashApi = exports.StashApi = function(protocol, hostname, port, user, passw
         return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/tags" );
     };
 
-    this.commits = function (projectKey, repositorySlug,branch) {
+    this.commits = function (projectKey, repositorySlug, branch) {
         var pReq = _buildPagedRequest(this);
-        return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/commits?until="+encodeURIComponent(branch) );
+        return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/commits?until=" + encodeURIComponent(branch) );
+    };
+
+    this.fileContents = function (projectKey, repositorySlug, fileName, branch) {
+        var pReq = _buildPagedRequest(this);
+        return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/browse/" + encodeURIComponent(fileName) + "?raw&at=" + encodeURIComponent(branch) );
     };
 
 }).call(StashApi.prototype);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-stash",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "REST Client for Atlassian's Stash repository",
   "main": "lib/stash.js",
   "engines": {
@@ -22,7 +22,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "lodash": "~2.4.1",
-    "request": "~2.27.0"
+    "requestretry": "~1.4.0"
   },
   "devDependencies": {
     "mocha": "~1.15.1",


### PR DESCRIPTION
Added file reading endpoint
Switched from request to requestretry, as stash seems to throw a ECONNRESET from time to time

note: could you also trigger a new build on https://www.npmjs.com/package/atlas-stash ?