### PR TITLE
Add a method to check the /merge api of Pull Requests

### DIFF
--- a/lib/stash.js
+++ b/lib/stash.js
@@ -91,6 +91,11 @@ var StashApi = exports.StashApi = function(protocol, hostname, port, user, passw
         return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/pull-requests" );
     };
 
+    this.pullRequestMerge = function(projectKey, repositorySlug, pullRequestId) {
+        var pReq = _buildPagedRequest(this);
+        return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/pull-requests/"+pullRequestId+"/merge");
+    };
+
     this.branches = function (projectKey, repositorySlug) {
         var pReq = _buildPagedRequest(this);
         return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/branches" );


### PR DESCRIPTION
For my purposes, I wish to be able to retrieve merge statuses from this path: /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/merge as in the documents here: https://developer.atlassian.com/static/rest/stash/3.11.3/stash-rest.html

This change only provides an implementation of the GET behaviour (viewing status and vetoes).

In a future change I may add POST functionality to actually perform the merge.