### PR TITLE
Add methods to retrieve build status (e.g. from Jenkins)

### DIFF
--- a/lib/stash.js
+++ b/lib/stash.js
@@ -3,6 +3,7 @@ var _ = require("lodash"),
     url = require("url"),
     request = require("requestretry"),
     PagedRequest = require("./paged-request").PagedRequest,
+    EventEmitter = require("events").EventEmitter,
     API_BASE = "/rest/api/1.0/";
 
 var StashApi = exports.StashApi = function(protocol, hostname, port, user, password) {
@@ -86,14 +87,44 @@ var StashApi = exports.StashApi = function(protocol, hostname, port, user, passw
         return pReq.start("GET", "projects/"+projectKey+"/repos");
     };
 
+    this.buildStatus = function (commit) {
+        var pReq = _buildPagedRequest(this);
+        // The Stash build integration plugin places build info at a different endpoint
+        return pReq.start("GET", "../../build-status/1.0/commits/"+commit);
+    };
+
     this.pullRequests = function (projectKey, repositorySlug) {
         var pReq = _buildPagedRequest(this);
         return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/pull-requests" );
     };
 
+    this.pullRequest = function (projectKey, repositorySlug, pullRequestId) {
+        var pReq = _buildPagedRequest(this);
+        return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/pull-requests/"+pullRequestId);
+    }
+
     this.pullRequestMerge = function(projectKey, repositorySlug, pullRequestId) {
         var pReq = _buildPagedRequest(this);
         return pReq.start("GET", "projects/"+projectKey+"/repos/"+repositorySlug+"/pull-requests/"+pullRequestId+"/merge");
+    };
+
+    this.pullRequestBuildStatus = function (projectKey, repositorySlug, pullRequestId) {
+        var that = this;
+
+        const statusEmitter = new EventEmitter();
+
+        this.pullRequest(projectKey, repositorySlug, pullRequestId)
+            .on('error', function(error) {statusEmitter.emit('error', error)})
+            .on('allPages', function(data) {
+                that.buildStatus(data[0]['fromRef']['latestChangeset'])
+                    .on('start', function() {statusEmitter.emit('start');})
+                    .on('newPage', function(page) {statusEmitter.emit('newPage', page);})
+                    .on('allPages', function(data) {statusEmitter.emit('allPages', data);})
+                    .on('end', function() {statusEmitter.emit('end');})
+                    .on('error', function(error) {statusEmitter.emit('error', error);});
+            });
+
+        return statusEmitter;
     };
 
     this.branches = function (projectKey, repositorySlug) {


### PR DESCRIPTION
This info is stored under the Stash Build Integration Plugin. Build statuses are associated with a git commit SHA, so can be retrieved by the method `buildStatus(commit)`. A helper method to retrieve the build status for the head of a pull request is also provided, `pullRequestBuildStatus(project, repo, pr_id)`, which uses the pull-request API to find the commit sha, then looks up the build status of that.